### PR TITLE
Enable mailto contact links

### DIFF
--- a/js/script.js
+++ b/js/script.js
@@ -21,11 +21,6 @@ document.addEventListener('DOMContentLoaded', () => {
     );
   }
 
-  // --- Neutralize any "mailto:" anchors (safety) ---
-  document.querySelectorAll('a[href^="mailto:"]').forEach(a => {
-    a.replaceWith(a.textContent || '');
-  });
-
   // --- Brief form handler (EN + RU) ---
   const form = document.getElementById('brief-form');
   if (form) {


### PR DESCRIPTION
## Summary
- preserve mailto anchors so contact email links remain clickable
- brief API includes Resend auto-reply confirmation

## Testing
- `node --check js/script.js`
- `node --check functions/api/brief.js`
- `node - <<'NODE'
import { onRequestPost } from './functions/api/brief.js';
global.fetch = async (url, opts) => new Response('{}', {status:200});
const request = new Request('http://example', { method:'POST', body: JSON.stringify({name:'Test', email:'user@example.com', project:'proj'})});
const env = {MAIL_FROM:'team@example.com', MAIL_TO:'internal@example.com', RESEND_API_KEY:'abc'};
const res = await onRequestPost({request, env});
console.log(res.status);
console.log(await res.text());
NODE`

------
https://chatgpt.com/codex/tasks/task_e_689c51dade0c83289023d3090f9c3000