### PR TITLE
Add security headers and analytics enhancements

### DIFF
--- a/_headers
+++ b/_headers
@@ -1,0 +1,12 @@
+/*
+  Strict-Transport-Security: max-age=31536000; includeSubDomains; preload
+  X-Content-Type-Options: nosniff
+  Referrer-Policy: strict-origin-when-cross-origin
+  Permissions-Policy: geolocation=(), microphone=(), camera=(), payment=(), usb=()
+  X-Frame-Options: SAMEORIGIN
+  Cache-Control: no-cache
+  Content-Security-Policy: default-src 'self'; script-src 'self' 'unsafe-inline' https://www.googletagmanager.com https://www.google-analytics.com; connect-src 'self' https://www.google-analytics.com https://region1.google-analytics.com; img-src 'self' data: https://www.google-analytics.com;
+
+/assets/*
+  Cache-Control: public, max-age=31536000, immutable
+

--- a/about.html
+++ b/about.html
@@ -3,6 +3,12 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <!-- Preconnects -->
+  <link rel="preconnect" href="https://www.googletagmanager.com" crossorigin>
+  <link rel="preconnect" href="https://www.google-analytics.com" crossorigin>
+
+  <!-- Preload Hero Image -->
+  <link rel="preload" as="image" href="/assets/hero-bg.jpg" fetchpriority="high">
   <!-- Primary SEO -->
   <title>About — Etern8 Tech</title>
   <meta name="description" content="Etern8 Tech builds AI-powered apps and conversion-first sites with a human-first approach. RU • UAE • KSA." />
@@ -55,12 +61,34 @@
   ]
   }
   </script>
+
+  <!-- Google Analytics -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-KQYJ1N0XLL"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){ dataLayer.push(arguments); }
+
+    // Consent Mode (минимальный вариант; если нет баннера — оставь granted)
+    gtag('consent', 'default', {
+      ad_storage: 'denied',
+      ad_user_data: 'denied',
+      ad_personalization: 'denied',
+      analytics_storage: 'granted'
+    });
+
+    gtag('js', new Date());
+    gtag('config', 'G-KQYJ1N0XLL', {
+      send_page_view: true,
+      anonymize_ip: true,
+      debug_mode: false
+    });
+  </script>
 </head>
 <body>
   <header class="site-header">
     <div class="container header-inner">
       <a href="/index.html" class="logo-link" aria-label="Etern8 Tech">
-        <img src="/assets/etern8_logo.png" alt="Etern8 Tech logo" class="logo-img" width="140" height="40" decoding="async">
+        <img src="/assets/etern8_logo.png" alt="Etern8 Tech logo" class="logo-img" width="140" height="40" decoding="async" loading="lazy">
       </a>
       <button id="menu-toggle" class="burger" aria-label="Toggle menu" aria-expanded="false">☰</button>
       <nav class="site-nav" id="site-nav">

--- a/contact.html
+++ b/contact.html
@@ -3,6 +3,12 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <!-- Preconnects -->
+  <link rel="preconnect" href="https://www.googletagmanager.com" crossorigin>
+  <link rel="preconnect" href="https://www.google-analytics.com" crossorigin>
+
+  <!-- Preload Hero Image -->
+  <link rel="preload" as="image" href="/assets/hero-bg.jpg" fetchpriority="high">
   <!-- Primary SEO -->
   <title>Contact — Etern8 Tech</title>
   <meta name="description" content="Get in touch via email or Telegram. We'll reply within 24 hours." />
@@ -55,12 +61,34 @@
   ]
   }
   </script>
+
+  <!-- Google Analytics -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-KQYJ1N0XLL"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){ dataLayer.push(arguments); }
+
+    // Consent Mode (минимальный вариант; если нет баннера — оставь granted)
+    gtag('consent', 'default', {
+      ad_storage: 'denied',
+      ad_user_data: 'denied',
+      ad_personalization: 'denied',
+      analytics_storage: 'granted'
+    });
+
+    gtag('js', new Date());
+    gtag('config', 'G-KQYJ1N0XLL', {
+      send_page_view: true,
+      anonymize_ip: true,
+      debug_mode: false
+    });
+  </script>
 </head>
 <body>
   <header class="site-header">
     <div class="container header-inner">
       <a href="/index.html" class="logo-link" aria-label="Etern8 Tech">
-        <img src="/assets/etern8_logo.png" alt="Etern8 Tech logo" class="logo-img" width="140" height="40" decoding="async">
+        <img src="/assets/etern8_logo.png" alt="Etern8 Tech logo" class="logo-img" width="140" height="40" decoding="async" loading="lazy">
       </a>
       <button id="menu-toggle" class="burger" aria-label="Toggle menu" aria-expanded="false">☰</button>
       <nav class="site-nav" id="site-nav">

--- a/index.html
+++ b/index.html
@@ -3,6 +3,12 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <!-- Preconnects -->
+  <link rel="preconnect" href="https://www.googletagmanager.com" crossorigin>
+  <link rel="preconnect" href="https://www.google-analytics.com" crossorigin>
+
+  <!-- Preload Hero Image -->
+  <link rel="preload" as="image" href="/assets/hero-bg.jpg" fetchpriority="high">
   <!-- Primary SEO -->
   <title>Launch Digital Products Twice as Fast — Etern8 Tech</title>
   <meta name="description" content="AI-powered apps, high-converting sites, and growth design. We deliver results in weeks, not months.">
@@ -57,9 +63,31 @@
   "potentialAction":{
     "@type":"SearchAction",
     "target":"https://etern8.tech/?q={search_term_string}",
-    "query-input":"required name=search_term_string"
+  "query-input":"required name=search_term_string"
   }
   }
+  </script>
+
+  <!-- Google Analytics -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-KQYJ1N0XLL"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){ dataLayer.push(arguments); }
+
+    // Consent Mode (минимальный вариант; если нет баннера — оставь granted)
+    gtag('consent', 'default', {
+      ad_storage: 'denied',
+      ad_user_data: 'denied',
+      ad_personalization: 'denied',
+      analytics_storage: 'granted'
+    });
+
+    gtag('js', new Date());
+    gtag('config', 'G-KQYJ1N0XLL', {
+      send_page_view: true,
+      anonymize_ip: true,
+      debug_mode: false
+    });
   </script>
 </head>
 <body>
@@ -67,7 +95,7 @@
   <header class="site-header">
     <div class="container header-inner">
       <a href="/index.html" class="logo-link" aria-label="Etern8 Tech">
-        <img src="/assets/etern8_logo.png" alt="Etern8 Tech logo" class="logo-img" width="140" height="40" decoding="async">
+        <img src="/assets/etern8_logo.png" alt="Etern8 Tech logo" class="logo-img" width="140" height="40" decoding="async" loading="lazy">
       </a>
       <button id="menu-toggle" class="burger" aria-label="Toggle menu" aria-expanded="false">☰</button>
       <nav class="site-nav" id="site-nav">
@@ -92,7 +120,7 @@
     <div class="container hero-inner">
       <h1>Scale Your Business. Infinitely.</h1>
       <p>We accelerate growth with AI-powered apps, conversion-first sites & bold design. Achieve results. Fast.</p>
-      <a href="#contact" class="btn-primary">Get Started</a>
+      <a href="#contact" class="btn-primary" data-ga="cta_get_started">Get Started</a>
     </div>
   </section>
 

--- a/js/script.js
+++ b/js/script.js
@@ -1,6 +1,9 @@
 // Etern8 Tech — unified header/lang/form script
 
 document.addEventListener('DOMContentLoaded', () => {
+  // Increase chance for good LCP
+  const heroImg = document.querySelector('.hero img');
+  if (heroImg) heroImg.setAttribute('fetchpriority', 'high');
   // --- Language switcher active state ---
   const isRU = location.pathname.startsWith('/ru/');
   document.querySelectorAll('.language-switcher .lang').forEach(a => {
@@ -76,6 +79,14 @@ document.addEventListener('DOMContentLoaded', () => {
         notice.textContent = isRU
           ? 'Спасибо! Ответим в течение 24 часов.'
           : 'Thanks! We’ll reply within 24 hours.';
+        if (window.gtag) {
+          gtag('event', 'generate_lead', {
+            event_category: 'form',
+            event_label: window.location.pathname,
+            value: 1,
+            currency: 'USD'
+          });
+        }
         form.reset();
       } catch (err) {
         console.error(err);
@@ -88,4 +99,15 @@ document.addEventListener('DOMContentLoaded', () => {
       }
     });
   }
+});
+
+document.addEventListener('click', e => {
+  const a = e.target.closest('[data-ga]');
+  if (!a || !window.gtag) return;
+  const name = a.getAttribute('data-ga');
+  gtag('event', name, {
+    event_category: 'cta',
+    event_label: location.pathname,
+    value: 1
+  });
 });

--- a/portfolio.html
+++ b/portfolio.html
@@ -3,6 +3,12 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <!-- Preconnects -->
+  <link rel="preconnect" href="https://www.googletagmanager.com" crossorigin>
+  <link rel="preconnect" href="https://www.google-analytics.com" crossorigin>
+
+  <!-- Preload Hero Image -->
+  <link rel="preload" as="image" href="/assets/hero-bg.jpg" fetchpriority="high">
   <!-- Primary SEO -->
   <title>Portfolio — Etern8 Tech</title>
   <meta name="description" content="Selected projects delivered by Etern8 Tech.">
@@ -58,12 +64,34 @@
   ]
   }
   </script>
+
+  <!-- Google Analytics -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-KQYJ1N0XLL"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){ dataLayer.push(arguments); }
+
+    // Consent Mode (минимальный вариант; если нет баннера — оставь granted)
+    gtag('consent', 'default', {
+      ad_storage: 'denied',
+      ad_user_data: 'denied',
+      ad_personalization: 'denied',
+      analytics_storage: 'granted'
+    });
+
+    gtag('js', new Date());
+    gtag('config', 'G-KQYJ1N0XLL', {
+      send_page_view: true,
+      anonymize_ip: true,
+      debug_mode: false
+    });
+  </script>
 </head>
 <body>
   <header class="site-header">
     <div class="container header-inner">
       <a href="/index.html" class="logo-link" aria-label="Etern8 Tech">
-        <img src="/assets/etern8_logo.png" alt="Etern8 Tech logo" class="logo-img" width="140" height="40" decoding="async">
+        <img src="/assets/etern8_logo.png" alt="Etern8 Tech logo" class="logo-img" width="140" height="40" decoding="async" loading="lazy">
       </a>
       <button id="menu-toggle" class="burger" aria-label="Toggle menu" aria-expanded="false">☰</button>
       <nav class="site-nav" id="site-nav">

--- a/privacy.html
+++ b/privacy.html
@@ -3,6 +3,12 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <!-- Preconnects -->
+  <link rel="preconnect" href="https://www.googletagmanager.com" crossorigin>
+  <link rel="preconnect" href="https://www.google-analytics.com" crossorigin>
+
+  <!-- Preload Hero Image -->
+  <link rel="preload" as="image" href="/assets/hero-bg.jpg" fetchpriority="high">
   <!-- Primary SEO -->
   <title>Privacy Policy — Etern8 Tech</title>
   <meta name="description" content="Privacy policy for Etern8 Tech." />
@@ -58,12 +64,34 @@
   ]
   }
   </script>
+
+  <!-- Google Analytics -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-KQYJ1N0XLL"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){ dataLayer.push(arguments); }
+
+    // Consent Mode (минимальный вариант; если нет баннера — оставь granted)
+    gtag('consent', 'default', {
+      ad_storage: 'denied',
+      ad_user_data: 'denied',
+      ad_personalization: 'denied',
+      analytics_storage: 'granted'
+    });
+
+    gtag('js', new Date());
+    gtag('config', 'G-KQYJ1N0XLL', {
+      send_page_view: true,
+      anonymize_ip: true,
+      debug_mode: false
+    });
+  </script>
 </head>
 <body>
   <header class="site-header">
     <div class="container header-inner">
       <a href="/index.html" class="logo-link" aria-label="Etern8 Tech">
-        <img src="/assets/etern8_logo.png" alt="Etern8 Tech logo" class="logo-img" width="140" height="40" decoding="async">
+        <img src="/assets/etern8_logo.png" alt="Etern8 Tech logo" class="logo-img" width="140" height="40" decoding="async" loading="lazy">
       </a>
       <button id="menu-toggle" class="burger" aria-label="Toggle menu" aria-expanded="false">☰</button>
       <nav class="site-nav" id="site-nav">

--- a/ru/about.html
+++ b/ru/about.html
@@ -3,6 +3,12 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <!-- Preconnects -->
+  <link rel="preconnect" href="https://www.googletagmanager.com" crossorigin>
+  <link rel="preconnect" href="https://www.google-analytics.com" crossorigin>
+
+  <!-- Preload Hero Image -->
+  <link rel="preload" as="image" href="/assets/hero-bg.jpg" fetchpriority="high">
   <!-- Primary SEO -->
   <title>О нас — Etern8 Tech</title>
   <meta name="description" content="Etern8 Tech создаёт приложения на ИИ и сайты с высокой конверсией, придерживаясь принципа «человек прежде всего». Россия • ОАЭ • КСА." />
@@ -58,12 +64,34 @@
   ]
   }
   </script>
+
+  <!-- Google Analytics -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-KQYJ1N0XLL"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){ dataLayer.push(arguments); }
+
+    // Consent Mode (минимальный вариант; если нет баннера — оставь granted)
+    gtag('consent', 'default', {
+      ad_storage: 'denied',
+      ad_user_data: 'denied',
+      ad_personalization: 'denied',
+      analytics_storage: 'granted'
+    });
+
+    gtag('js', new Date());
+    gtag('config', 'G-KQYJ1N0XLL', {
+      send_page_view: true,
+      anonymize_ip: true,
+      debug_mode: false
+    });
+  </script>
 </head>
 <body>
   <header class="site-header">
     <div class="container header-inner">
       <a href="/ru/index.html" class="logo-link" aria-label="Etern8 Tech">
-        <img src="/assets/etern8_logo.png" alt="Etern8 Tech logo" class="logo-img" width="140" height="40" decoding="async">
+        <img src="/assets/etern8_logo.png" alt="Etern8 Tech logo" class="logo-img" width="140" height="40" decoding="async" loading="lazy">
       </a>
       <button id="menu-toggle" class="burger" aria-label="Toggle menu" aria-expanded="false">☰</button>
       <nav class="site-nav" id="site-nav">

--- a/ru/contact.html
+++ b/ru/contact.html
@@ -3,6 +3,12 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <!-- Preconnects -->
+  <link rel="preconnect" href="https://www.googletagmanager.com" crossorigin>
+  <link rel="preconnect" href="https://www.google-analytics.com" crossorigin>
+
+  <!-- Preload Hero Image -->
+  <link rel="preload" as="image" href="/assets/hero-bg.jpg" fetchpriority="high">
   <!-- Primary SEO -->
   <title>Контакты — Etern8 Tech</title>
   <meta name="description" content="Напишите нам на почту или в Telegram. Ответим в течение 24 часов." />
@@ -55,12 +61,34 @@
   ]
   }
   </script>
+
+  <!-- Google Analytics -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-KQYJ1N0XLL"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){ dataLayer.push(arguments); }
+
+    // Consent Mode (минимальный вариант; если нет баннера — оставь granted)
+    gtag('consent', 'default', {
+      ad_storage: 'denied',
+      ad_user_data: 'denied',
+      ad_personalization: 'denied',
+      analytics_storage: 'granted'
+    });
+
+    gtag('js', new Date());
+    gtag('config', 'G-KQYJ1N0XLL', {
+      send_page_view: true,
+      anonymize_ip: true,
+      debug_mode: false
+    });
+  </script>
 </head>
 <body>
   <header class="site-header">
     <div class="container header-inner">
       <a href="/ru/index.html" class="logo-link" aria-label="Etern8 Tech">
-        <img src="/assets/etern8_logo.png" alt="Etern8 Tech logo" class="logo-img" width="140" height="40" decoding="async">
+        <img src="/assets/etern8_logo.png" alt="Etern8 Tech logo" class="logo-img" width="140" height="40" decoding="async" loading="lazy">
       </a>
       <button id="menu-toggle" class="burger" aria-label="Toggle menu" aria-expanded="false">☰</button>
       <nav class="site-nav" id="site-nav">

--- a/ru/index.html
+++ b/ru/index.html
@@ -3,6 +3,12 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <!-- Preconnects -->
+  <link rel="preconnect" href="https://www.googletagmanager.com" crossorigin>
+  <link rel="preconnect" href="https://www.google-analytics.com" crossorigin>
+
+  <!-- Preload Hero Image -->
+  <link rel="preload" as="image" href="/assets/hero-bg.jpg" fetchpriority="high">
   <!-- Primary SEO -->
   <title>Запускайте цифровые продукты вдвое быстрее — Etern8 Tech</title>
   <meta name="description" content="Приложения на ИИ, сайты с высокой конверсией и дизайн роста. Мы делаем результат за недели, а не месяцы.">
@@ -57,9 +63,31 @@
   "potentialAction":{
     "@type":"SearchAction",
     "target":"https://etern8.tech/?q={search_term_string}",
-    "query-input":"required name=search_term_string"
+  "query-input":"required name=search_term_string"
   }
   }
+  </script>
+
+  <!-- Google Analytics -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-KQYJ1N0XLL"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){ dataLayer.push(arguments); }
+
+    // Consent Mode (минимальный вариант; если нет баннера — оставь granted)
+    gtag('consent', 'default', {
+      ad_storage: 'denied',
+      ad_user_data: 'denied',
+      ad_personalization: 'denied',
+      analytics_storage: 'granted'
+    });
+
+    gtag('js', new Date());
+    gtag('config', 'G-KQYJ1N0XLL', {
+      send_page_view: true,
+      anonymize_ip: true,
+      debug_mode: false
+    });
   </script>
 </head>
 <body>
@@ -67,7 +95,7 @@
   <header class="site-header">
     <div class="container header-inner">
       <a href="/ru/index.html" class="logo-link" aria-label="Etern8 Tech">
-        <img src="/assets/etern8_logo.png" alt="Etern8 Tech logo" class="logo-img" width="140" height="40" decoding="async">
+        <img src="/assets/etern8_logo.png" alt="Etern8 Tech logo" class="logo-img" width="140" height="40" decoding="async" loading="lazy">
       </a>
       <button id="menu-toggle" class="burger" aria-label="Toggle menu" aria-expanded="false">☰</button>
       <nav class="site-nav" id="site-nav">
@@ -92,7 +120,7 @@
     <div class="container hero-inner">
       <h1>Ускоряйте рост. Бесконечно.</h1>
       <p>Мы ускоряем рост с помощью приложений на ИИ, конверсионных сайтов и сильного дизайна. Результаты — быстро.</p>
-      <a href="#contact" class="btn-primary">Оставить заявку</a>
+      <a href="#contact" class="btn-primary" data-ga="cta_get_started">Оставить заявку</a>
     </div>
   </section>
 

--- a/ru/portfolio.html
+++ b/ru/portfolio.html
@@ -3,6 +3,12 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <!-- Preconnects -->
+  <link rel="preconnect" href="https://www.googletagmanager.com" crossorigin>
+  <link rel="preconnect" href="https://www.google-analytics.com" crossorigin>
+
+  <!-- Preload Hero Image -->
+  <link rel="preload" as="image" href="/assets/hero-bg.jpg" fetchpriority="high">
   <!-- Primary SEO -->
   <title>Портфолио — Etern8 Tech</title>
   <meta name="description" content="Выбранные проекты от Etern8 Tech.">
@@ -58,12 +64,34 @@
   ]
   }
   </script>
+
+  <!-- Google Analytics -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-KQYJ1N0XLL"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){ dataLayer.push(arguments); }
+
+    // Consent Mode (минимальный вариант; если нет баннера — оставь granted)
+    gtag('consent', 'default', {
+      ad_storage: 'denied',
+      ad_user_data: 'denied',
+      ad_personalization: 'denied',
+      analytics_storage: 'granted'
+    });
+
+    gtag('js', new Date());
+    gtag('config', 'G-KQYJ1N0XLL', {
+      send_page_view: true,
+      anonymize_ip: true,
+      debug_mode: false
+    });
+  </script>
 </head>
 <body>
   <header class="site-header">
     <div class="container header-inner">
       <a href="/ru/index.html" class="logo-link" aria-label="Etern8 Tech">
-        <img src="/assets/etern8_logo.png" alt="Etern8 Tech logo" class="logo-img" width="140" height="40" decoding="async">
+        <img src="/assets/etern8_logo.png" alt="Etern8 Tech logo" class="logo-img" width="140" height="40" decoding="async" loading="lazy">
       </a>
       <button id="menu-toggle" class="burger" aria-label="Toggle menu" aria-expanded="false">☰</button>
       <nav class="site-nav" id="site-nav">

--- a/ru/privacy.html
+++ b/ru/privacy.html
@@ -3,6 +3,12 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <!-- Preconnects -->
+  <link rel="preconnect" href="https://www.googletagmanager.com" crossorigin>
+  <link rel="preconnect" href="https://www.google-analytics.com" crossorigin>
+
+  <!-- Preload Hero Image -->
+  <link rel="preload" as="image" href="/assets/hero-bg.jpg" fetchpriority="high">
   <!-- Primary SEO -->
   <title>Политика конфиденциальности — Etern8 Tech</title>
   <meta name="description" content="Политика конфиденциальности Etern8 Tech." />
@@ -58,12 +64,34 @@
   ]
   }
   </script>
+
+  <!-- Google Analytics -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-KQYJ1N0XLL"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){ dataLayer.push(arguments); }
+
+    // Consent Mode (минимальный вариант; если нет баннера — оставь granted)
+    gtag('consent', 'default', {
+      ad_storage: 'denied',
+      ad_user_data: 'denied',
+      ad_personalization: 'denied',
+      analytics_storage: 'granted'
+    });
+
+    gtag('js', new Date());
+    gtag('config', 'G-KQYJ1N0XLL', {
+      send_page_view: true,
+      anonymize_ip: true,
+      debug_mode: false
+    });
+  </script>
 </head>
 <body>
   <header class="site-header">
     <div class="container header-inner">
       <a href="/ru/index.html" class="logo-link" aria-label="Etern8 Tech">
-        <img src="/assets/etern8_logo.png" alt="Etern8 Tech logo" class="logo-img" width="140" height="40" decoding="async">
+        <img src="/assets/etern8_logo.png" alt="Etern8 Tech logo" class="logo-img" width="140" height="40" decoding="async" loading="lazy">
       </a>
       <button id="menu-toggle" class="burger" aria-label="Toggle menu" aria-expanded="false">☰</button>
       <nav class="site-nav" id="site-nav">

--- a/ru/services.html
+++ b/ru/services.html
@@ -3,6 +3,12 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <!-- Preconnects -->
+  <link rel="preconnect" href="https://www.googletagmanager.com" crossorigin>
+  <link rel="preconnect" href="https://www.google-analytics.com" crossorigin>
+
+  <!-- Preload Hero Image -->
+  <link rel="preload" as="image" href="/assets/hero-bg.jpg" fetchpriority="high">
   <!-- Primary SEO -->
   <title>Услуги — Etern8 Tech</title>
   <meta name="description" content="Разработка приложений, сайты, интеграция ИИ и дизайн — запускайтесь быстро.">
@@ -91,12 +97,34 @@
   ]
   }
   </script>
+
+  <!-- Google Analytics -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-KQYJ1N0XLL"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){ dataLayer.push(arguments); }
+
+    // Consent Mode (минимальный вариант; если нет баннера — оставь granted)
+    gtag('consent', 'default', {
+      ad_storage: 'denied',
+      ad_user_data: 'denied',
+      ad_personalization: 'denied',
+      analytics_storage: 'granted'
+    });
+
+    gtag('js', new Date());
+    gtag('config', 'G-KQYJ1N0XLL', {
+      send_page_view: true,
+      anonymize_ip: true,
+      debug_mode: false
+    });
+  </script>
 </head>
 <body>
   <header class="site-header">
     <div class="container header-inner">
       <a href="/ru/index.html" class="logo-link" aria-label="Etern8 Tech">
-        <img src="/assets/etern8_logo.png" alt="Etern8 Tech logo" class="logo-img" width="140" height="40" decoding="async">
+        <img src="/assets/etern8_logo.png" alt="Etern8 Tech logo" class="logo-img" width="140" height="40" decoding="async" loading="lazy">
       </a>
       <button id="menu-toggle" class="burger" aria-label="Toggle menu" aria-expanded="false">☰</button>
       <nav class="site-nav" id="site-nav">
@@ -135,7 +163,7 @@
           <p><strong>Что делаем:</strong> чатботы для Telegram/WhatsApp/Web, интеграция с CRM, передача оператору.</p>
           <p><strong>Стек:</strong> Node.js, Python, Dialogflow, GPT-4.</p>
           <p><strong>Процесс:</strong> бриф → спринт 0 → dev-спринты → QA → запуск.</p>
-          <a href="/ru/contact.html" class="btn-primary">Оставить заявку</a>
+          <a href="/ru/contact.html" class="btn-primary" data-ga="cta_get_started">Оставить заявку</a>
       </div>
     </article>
 
@@ -150,7 +178,7 @@
           <p><strong>Что делаем:</strong> конверсионные одностраничники на Webflow/Tilda/чистом HTML.</p>
           <p><strong>Стек:</strong> Webflow CMS, HTML5, CSS3, GSAP.</p>
           <p><strong>Процесс:</strong> UX → разработка → оптимизация → A/B‑тесты.</p>
-          <a href="/ru/contact.html" class="btn-primary">Оставить заявку</a>
+          <a href="/ru/contact.html" class="btn-primary" data-ga="cta_get_started">Оставить заявку</a>
       </div>
     </article>
 
@@ -168,7 +196,7 @@
           <p><strong>Что делаем:</strong> генерация контента, аналитика, предиктивные модели.</p>
           <p><strong>Стек:</strong> Llama-3, LangChain, Pinecone, AWS.</p>
           <p><strong>Процесс:</strong> сбор данных → дообучение → интеграция → мониторинг.</p>
-          <a href="/ru/contact.html" class="btn-primary">Оставить заявку</a>
+          <a href="/ru/contact.html" class="btn-primary" data-ga="cta_get_started">Оставить заявку</a>
       </div>
     </article>
   </section>

--- a/ru/terms.html
+++ b/ru/terms.html
@@ -3,6 +3,12 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <!-- Preconnects -->
+  <link rel="preconnect" href="https://www.googletagmanager.com" crossorigin>
+  <link rel="preconnect" href="https://www.google-analytics.com" crossorigin>
+
+  <!-- Preload Hero Image -->
+  <link rel="preload" as="image" href="/assets/hero-bg.jpg" fetchpriority="high">
   <!-- Primary SEO -->
   <title>Условия использования — Etern8 Tech</title>
   <meta name="description" content="Условия использования Etern8 Tech." />
@@ -58,12 +64,34 @@
   ]
   }
   </script>
+
+  <!-- Google Analytics -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-KQYJ1N0XLL"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){ dataLayer.push(arguments); }
+
+    // Consent Mode (минимальный вариант; если нет баннера — оставь granted)
+    gtag('consent', 'default', {
+      ad_storage: 'denied',
+      ad_user_data: 'denied',
+      ad_personalization: 'denied',
+      analytics_storage: 'granted'
+    });
+
+    gtag('js', new Date());
+    gtag('config', 'G-KQYJ1N0XLL', {
+      send_page_view: true,
+      anonymize_ip: true,
+      debug_mode: false
+    });
+  </script>
 </head>
 <body>
   <header class="site-header">
     <div class="container header-inner">
       <a href="/ru/index.html" class="logo-link" aria-label="Etern8 Tech">
-        <img src="/assets/etern8_logo.png" alt="Etern8 Tech logo" class="logo-img" width="140" height="40" decoding="async">
+        <img src="/assets/etern8_logo.png" alt="Etern8 Tech logo" class="logo-img" width="140" height="40" decoding="async" loading="lazy">
       </a>
       <button id="menu-toggle" class="burger" aria-label="Toggle menu" aria-expanded="false">☰</button>
       <nav class="site-nav" id="site-nav">

--- a/ru/why.html
+++ b/ru/why.html
@@ -3,6 +3,12 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <!-- Preconnects -->
+  <link rel="preconnect" href="https://www.googletagmanager.com" crossorigin>
+  <link rel="preconnect" href="https://www.google-analytics.com" crossorigin>
+
+  <!-- Preload Hero Image -->
+  <link rel="preload" as="image" href="/assets/hero-bg.jpg" fetchpriority="high">
   <!-- Primary SEO -->
   <title>Почему Etern8 — Etern8 Tech</title>
   <meta name="description" content="Пять причин, по которым клиенты выбирают Etern8: скорость, мастерство, ИИ‑подход, рост на данных, глобальная доставка." />
@@ -58,12 +64,34 @@
   ]
   }
   </script>
+
+  <!-- Google Analytics -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-KQYJ1N0XLL"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){ dataLayer.push(arguments); }
+
+    // Consent Mode (минимальный вариант; если нет баннера — оставь granted)
+    gtag('consent', 'default', {
+      ad_storage: 'denied',
+      ad_user_data: 'denied',
+      ad_personalization: 'denied',
+      analytics_storage: 'granted'
+    });
+
+    gtag('js', new Date());
+    gtag('config', 'G-KQYJ1N0XLL', {
+      send_page_view: true,
+      anonymize_ip: true,
+      debug_mode: false
+    });
+  </script>
 </head>
 <body>
   <header class="site-header">
     <div class="container header-inner">
       <a href="/ru/index.html" class="logo-link" aria-label="Etern8 Tech">
-        <img src="/assets/etern8_logo.png" alt="Etern8 Tech logo" class="logo-img" width="140" height="40" decoding="async">
+        <img src="/assets/etern8_logo.png" alt="Etern8 Tech logo" class="logo-img" width="140" height="40" decoding="async" loading="lazy">
       </a>
       <button id="menu-toggle" class="burger" aria-label="Toggle menu" aria-expanded="false">☰</button>
       <nav class="site-nav" id="site-nav">

--- a/services.html
+++ b/services.html
@@ -3,6 +3,12 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <!-- Preconnects -->
+  <link rel="preconnect" href="https://www.googletagmanager.com" crossorigin>
+  <link rel="preconnect" href="https://www.google-analytics.com" crossorigin>
+
+  <!-- Preload Hero Image -->
+  <link rel="preload" as="image" href="/assets/hero-bg.jpg" fetchpriority="high">
   <!-- Primary SEO -->
   <title>Services — Etern8 Tech</title>
   <meta name="description" content="App development, web development, AI integration, and design services to launch fast.">
@@ -91,13 +97,35 @@
   ]
   }
   </script>
+
+  <!-- Google Analytics -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-KQYJ1N0XLL"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){ dataLayer.push(arguments); }
+
+    // Consent Mode (минимальный вариант; если нет баннера — оставь granted)
+    gtag('consent', 'default', {
+      ad_storage: 'denied',
+      ad_user_data: 'denied',
+      ad_personalization: 'denied',
+      analytics_storage: 'granted'
+    });
+
+    gtag('js', new Date());
+    gtag('config', 'G-KQYJ1N0XLL', {
+      send_page_view: true,
+      anonymize_ip: true,
+      debug_mode: false
+    });
+  </script>
 </head>
 <body>
   <!-- Header -->
   <header class="site-header">
     <div class="container header-inner">
       <a href="/index.html" class="logo-link" aria-label="Etern8 Tech">
-        <img src="/assets/etern8_logo.png" alt="Etern8 Tech logo" class="logo-img" width="140" height="40" decoding="async">
+        <img src="/assets/etern8_logo.png" alt="Etern8 Tech logo" class="logo-img" width="140" height="40" decoding="async" loading="lazy">
       </a>
       <button id="menu-toggle" class="burger" aria-label="Toggle menu" aria-expanded="false">☰</button>
       <nav class="site-nav" id="site-nav">
@@ -136,7 +164,7 @@
         <p><strong>What we do:</strong> Telegram/WhatsApp/Web chatbots, CRM integration, handoff to agent.</p>
         <p><strong>Tech stack:</strong> Node.js, Python, Dialogflow, GPT-4.</p>
         <p><strong>Process:</strong> Brief → Sprint 0 → Dev sprints → QA → Launch.</p>
-        <a href="contact.html" class="btn-primary">Get Started</a>
+        <a href="contact.html" class="btn-primary" data-ga="cta_get_started">Get Started</a>
       </div>
     </article>
 
@@ -151,7 +179,7 @@
         <p><strong>What we do:</strong> High-converting one-pagers on Webflow/Tilda/custom HTML.</p>
         <p><strong>Tech stack:</strong> Webflow CMS, HTML5, CSS3, GSAP.</p>
         <p><strong>Process:</strong> UX → Dev → Optimization → A/B testing.</p>
-        <a href="contact.html" class="btn-primary">Get Started</a>
+        <a href="contact.html" class="btn-primary" data-ga="cta_get_started">Get Started</a>
       </div>
     </article>
 
@@ -169,7 +197,7 @@
         <p><strong>What we do:</strong> Content generation, analytics, predictive models.</p>
         <p><strong>Tech stack:</strong> Llama-3, LangChain, Pinecone, AWS.</p>
         <p><strong>Process:</strong> Data intake → fine-tuning → integration → monitoring.</p>
-        <a href="contact.html" class="btn-primary">Get Started</a>
+        <a href="contact.html" class="btn-primary" data-ga="cta_get_started">Get Started</a>
       </div>
     </article>
   </section>

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -7,6 +7,8 @@
   <url><loc>https://etern8.tech/why.html</loc><changefreq>monthly</changefreq><priority>0.7</priority></url>
   <url><loc>https://etern8.tech/about.html</loc><changefreq>monthly</changefreq><priority>0.6</priority></url>
   <url><loc>https://etern8.tech/contact.html</loc><changefreq>weekly</changefreq><priority>0.8</priority></url>
+  <url><loc>https://etern8.tech/privacy.html</loc><changefreq>yearly</changefreq><priority>0.3</priority></url>
+  <url><loc>https://etern8.tech/terms.html</loc><changefreq>yearly</changefreq><priority>0.3</priority></url>
 
   <!-- RU -->
   <url><loc>https://etern8.tech/ru/</loc><changefreq>weekly</changefreq><priority>1.0</priority></url>
@@ -15,4 +17,6 @@
   <url><loc>https://etern8.tech/ru/why.html</loc><changefreq>monthly</changefreq><priority>0.7</priority></url>
   <url><loc>https://etern8.tech/ru/about.html</loc><changefreq>monthly</changefreq><priority>0.6</priority></url>
   <url><loc>https://etern8.tech/ru/contact.html</loc><changefreq>weekly</changefreq><priority>0.8</priority></url>
+  <url><loc>https://etern8.tech/ru/privacy.html</loc><changefreq>yearly</changefreq><priority>0.3</priority></url>
+  <url><loc>https://etern8.tech/ru/terms.html</loc><changefreq>yearly</changefreq><priority>0.3</priority></url>
 </urlset>

--- a/terms.html
+++ b/terms.html
@@ -3,6 +3,12 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <!-- Preconnects -->
+  <link rel="preconnect" href="https://www.googletagmanager.com" crossorigin>
+  <link rel="preconnect" href="https://www.google-analytics.com" crossorigin>
+
+  <!-- Preload Hero Image -->
+  <link rel="preload" as="image" href="/assets/hero-bg.jpg" fetchpriority="high">
   <!-- Primary SEO -->
   <title>Terms of Service — Etern8 Tech</title>
   <meta name="description" content="Terms of service for Etern8 Tech." />
@@ -58,12 +64,34 @@
   ]
   }
   </script>
+
+  <!-- Google Analytics -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-KQYJ1N0XLL"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){ dataLayer.push(arguments); }
+
+    // Consent Mode (минимальный вариант; если нет баннера — оставь granted)
+    gtag('consent', 'default', {
+      ad_storage: 'denied',
+      ad_user_data: 'denied',
+      ad_personalization: 'denied',
+      analytics_storage: 'granted'
+    });
+
+    gtag('js', new Date());
+    gtag('config', 'G-KQYJ1N0XLL', {
+      send_page_view: true,
+      anonymize_ip: true,
+      debug_mode: false
+    });
+  </script>
 </head>
 <body>
   <header class="site-header">
     <div class="container header-inner">
       <a href="/index.html" class="logo-link" aria-label="Etern8 Tech">
-        <img src="/assets/etern8_logo.png" alt="Etern8 Tech logo" class="logo-img" width="140" height="40" decoding="async">
+        <img src="/assets/etern8_logo.png" alt="Etern8 Tech logo" class="logo-img" width="140" height="40" decoding="async" loading="lazy">
       </a>
       <button id="menu-toggle" class="burger" aria-label="Toggle menu" aria-expanded="false">☰</button>
       <nav class="site-nav" id="site-nav">

--- a/why.html
+++ b/why.html
@@ -3,6 +3,12 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <!-- Preconnects -->
+  <link rel="preconnect" href="https://www.googletagmanager.com" crossorigin>
+  <link rel="preconnect" href="https://www.google-analytics.com" crossorigin>
+
+  <!-- Preload Hero Image -->
+  <link rel="preload" as="image" href="/assets/hero-bg.jpg" fetchpriority="high">
   <!-- Primary SEO -->
   <title>Why Etern8 — Etern8 Tech</title>
   <meta name="description" content="Five reasons clients choose Etern8: speed, craftsmanship, AI-first, data-driven growth, global delivery." />
@@ -55,12 +61,34 @@
   ]
   }
   </script>
+
+  <!-- Google Analytics -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-KQYJ1N0XLL"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){ dataLayer.push(arguments); }
+
+    // Consent Mode (минимальный вариант; если нет баннера — оставь granted)
+    gtag('consent', 'default', {
+      ad_storage: 'denied',
+      ad_user_data: 'denied',
+      ad_personalization: 'denied',
+      analytics_storage: 'granted'
+    });
+
+    gtag('js', new Date());
+    gtag('config', 'G-KQYJ1N0XLL', {
+      send_page_view: true,
+      anonymize_ip: true,
+      debug_mode: false
+    });
+  </script>
 </head>
 <body>
   <header class="site-header">
     <div class="container header-inner">
       <a href="/index.html" class="logo-link" aria-label="Etern8 Tech">
-        <img src="/assets/etern8_logo.png" alt="Etern8 Tech logo" class="logo-img" width="140" height="40" decoding="async">
+        <img src="/assets/etern8_logo.png" alt="Etern8 Tech logo" class="logo-img" width="140" height="40" decoding="async" loading="lazy">
       </a>
       <button id="menu-toggle" class="burger" aria-label="Toggle menu" aria-expanded="false">☰</button>
       <nav class="site-nav" id="site-nav">


### PR DESCRIPTION
## Summary
- add Cloudflare security headers and asset caching rules
- integrate GA4 with preconnects, hero preload and CTA tracking
- expand sitemap with RU pages for privacy and terms

## Testing
- `npx htmlhint "**/*.html"`


------
https://chatgpt.com/codex/tasks/task_e_689c60101674832893d9d4ea57c4383d